### PR TITLE
Text inclusion, locked layer exclusion. 

### DIFF
--- a/SelectLayersByColor.sketchplugin
+++ b/SelectLayersByColor.sketchplugin
@@ -6,7 +6,7 @@
 
 var referenceColors = [];
 
-for (var c = 0; c < selection.count(); c++) {
+for (var c = 0; c < selection.count(); c++) {
   var color = getColorOf(selection[c]);
   var hexColor = "#" + color.hexValue();
   referenceColors.push(hexColor);
@@ -20,15 +20,14 @@ for (var i = 0; i < doc.pages().count(); i++) {
 
   var page = doc.pages().objectAtIndex(i);
 
-  for (var j = 0; j < page.artboards().count(); j++) {
+  for (var j = 0; j < page.artboards().count(); j++) {
 
     var artboard = page.artboards().objectAtIndex(j);
 
     for (var k = 0; k < artboard.layers().count(); k++) {
 
       var layer = artboard.layers().objectAtIndex(k);
-      parse(layer, 0);
-
+      if (!layer.isLocked())  parse(layer, 0);
     }
   }
 }
@@ -40,11 +39,13 @@ for (var i = 0; i < doc.pages().count(); i++) {
 // Util functions
 
 function parse(layer, level) {
+  if (layer.isLocked()) return;
+
   if (layer.class() == MSLayerGroup) {
     for (var i = 0; i < layer.layers().count(); i++) {
       parse(layer.layers().objectAtIndex(i), level + 1);
     }
-  } else if (layer.class() == MSShapeGroup){
+  } else if (layer.class() == MSShapeGroup || layer.class() == MSTextLayer){
     var color = getColorOf(layer);
     if (color != undefined) {
       var hexColor = "#" + color.hexValue();


### PR DESCRIPTION
Great plugin :+1:. I was looking for something like this so I can copy a design side by side, select everything with a colours to change out for a different swatch. Just had a few issues with it, such as I wanted it to exclude locked items from the selection and also I wanted it to select text elements with the same colour. 

Feel free not to merge it if you think these issues are too specific to my need :smile: 
